### PR TITLE
change CVE to dedicated sample ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 >
 > You start the program through a Shell of your choosing (CMD, PowerShell, Windows Terminal) with the following command:
 >
-> __Either__ ```CVEInfo.exe %CVE-Number e.g. CVE-2022-69420%```
+> __Either__ ```CVEInfo.exe %CVE-Number e.g. CVE-2014-99999%```
 >
-> __Or__ ```cveinfo %CVE-Number e.g. CVE-2022-69420%```
+> __Or__ ```cveinfo %CVE-Number e.g. CVE-2014-99999%```
 >
 > Additionaly, if you want the CVE-Description aswell, start CVEInfo with a "-d" argument.
 >
-> ```cveinfo %CVE-Number e.g. CVE-2022-69420% -d```
+> ```cveinfo %CVE-Number e.g. CVE-2014-99999% -d```
 
 ## API Key Information
 > As written [here](https://nvd.nist.gov/developers/start-here), the NVD-API has rate-limits built in.


### PR DESCRIPTION
The CVE ID you chose may become a real identifier this year. MITRE has several sample IDs for use like this: CVE-2014-9999
CVE-2014-99999
CVE-2014-999999
CVE-2014-54321
CVE-2014-456132
CVE-2014-123456
CVE-2014-10000
CVE-2014-100000